### PR TITLE
Created PortalStyles and default page injection

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -210,10 +210,14 @@
     <Compile Include="Entities\Modules\Settings\SettingsRepository.cs" />
     <Compile Include="Entities\Modules\Settings\TabModuleSettingAttribute.cs" />
     <Compile Include="Entities\Portals\IPortalSettingHandlers.cs" />
+    <Compile Include="Entities\Portals\IPortalStylesController.cs" />
     <Compile Include="Entities\Portals\IPortalTemplateEventHandlers.cs" />
     <Compile Include="Entities\Portals\PortalAliasExtensions.cs" />
     <Compile Include="Entities\Portals\PortalSettingUpdatedEventArgs.cs" />
+    <Compile Include="Entities\Portals\PortalStylesController.cs" />
     <Compile Include="Entities\Portals\PortalTemplateEventArgs.cs" />
+    <Compile Include="Entities\Portals\PortalStyles.cs" />
+    <Compile Include="Entities\Portals\StyleColorBase.cs" />
     <Compile Include="Entities\Users\UpdateUserEventArgs.cs" />
     <Compile Include="Entities\Content\ContentTypeMemberNameFixer.cs" />
     <Compile Include="Collections\EnumerableExtensions.cs" />

--- a/DNN Platform/Library/Entities/Portals/IPortalStylesController.cs
+++ b/DNN Platform/Library/Entities/Portals/IPortalStylesController.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright
+
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2018
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+#endregion
+
+using System;
+
+namespace DotNetNuke.Entities.Portals
+{
+    public interface IPortalStylesController
+    {
+        /// <summary>
+        /// Gets the portal styles for the given portalId
+        /// </summary>
+        /// <param name="portalId">ID of the portal</param>
+        /// <returns></returns>
+        PortalStyles GetPortalStyles(int portalId);
+
+        /// <summary>
+        /// Creates or updates the portal styles for the given portal
+        /// </summary>
+        /// <param name="portalId">The Id of the portal</param>
+        /// <param name="portalStyles">The styles to save</param>
+        void UpdatePortalStyles(int portalId, PortalStyles portalStyles);
+    }
+}

--- a/DNN Platform/Library/Entities/Portals/IPortalStylesController.cs
+++ b/DNN Platform/Library/Entities/Portals/IPortalStylesController.cs
@@ -1,23 +1,7 @@
 ﻿#region Copyright
 
-// 
-// DotNetNuke® - http://www.dotnetnuke.com
-// Copyright (c) 2002-2018
-// by DotNetNuke Corporation
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
-// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
-// of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-// DEALINGS IN THE SOFTWARE.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #endregion
 
@@ -25,6 +9,9 @@ using System;
 
 namespace DotNetNuke.Entities.Portals
 {
+    /// <summary>
+    /// Manages reading and updating portal styles
+    /// </summary>
     public interface IPortalStylesController
     {
         /// <summary>

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -179,93 +179,226 @@ namespace DotNetNuke.Entities.Portals
 
         #region Auto-Properties
 
+        /// <summary>
+        /// The ID of the active tab (page)
+        /// </summary>
         public TabInfo ActiveTab { get; set; }
 
-		public int AdministratorId { get; set; }
+        /// <summary>
+        /// The ID of the user that is this portal administrator
+        /// </summary>
+        public int AdministratorId { get; set; }
 
-		public int AdministratorRoleId { get; set; }
+        /// <summary>
+        /// The dole ID of the Administrators role for this portal
+        /// </summary>
+        public int AdministratorRoleId { get; set; }
 
-		public string AdministratorRoleName { get; set; }
+        /// <summary>
+        /// The role name of the role that has administration rights on the portal (usually Administrators)
+        /// </summary>
+        public string AdministratorRoleName { get; set; }
 
-		public int AdminTabId { get; set; }
+        /// <summary>
+        /// The ID of the tab (page) that contains the administration modules
+        /// </summary>
+        public int AdminTabId { get; set; }
 
-		public string BackgroundFile { get; set; }
+        /// <summary>
+        /// A file that can optionnaly be used as a background image if the theme supports it
+        /// </summary>
+        public string BackgroundFile { get; set; }
 
-		public int BannerAdvertising { get; set; }
+        /// <summary>
+        /// Could be used by the Vendors/Banner module, there is no built-in UI to manage this setting
+        /// </summary>
+        public int BannerAdvertising { get; set; }
 
-		public string CultureCode { get; set; }
+        /// <summary>
+        /// The culture code in a format that represents the language and country as in "fr-CA" for French Canada
+        /// </summary>
+        public string CultureCode { get; set; }
 
-		public string Currency { get; set; }
 
-		public string DefaultLanguage { get; set; }
+        /// <summary>
+        /// The currency used for this portal, in the platform this is used for Paypal subscriptions
+        /// </summary>
+        public string Currency { get; set; }
 
-		public string Description { get; set; }
+        /// <summary>
+        /// The culture code of the default language for this portal
+        /// </summary>
+        public string DefaultLanguage { get; set; }
 
-		public string Email { get; set; }
+        /// <summary>
+        /// The description of the portal, used for seo purposes and rss feeds
+        /// </summary>
+        public string Description { get; set; }
 
+        /// <summary>
+        /// The portal owner email address
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// If used, the portal will expire (stop working) on that date and time
+        /// </summary>
         public DateTime ExpiryDate { get; set; }
 
-		public string FooterText { get; set; }
+        /// <summary>
+        /// Configurable text that can be injected by the theme, usually used for copyright notice and consumed by the copyright skinObject
+        /// [year] in this text will get replaced by the current year.
+        /// </summary>
+        public string FooterText { get; set; }
 
-		public Guid GUID { get; set; }
+        /// <summary>
+        /// A globally unique identifier for this portal, used for such things as encryption and licensing
+        /// </summary>
+        public Guid GUID { get; set; }
 
-		public string HomeDirectory { get; set; }
+        /// <summary>
+        /// The public facing portal home directory (url)
+        /// </summary>
+        public string HomeDirectory { get; set; }
 
-		public string HomeSystemDirectory { get; set; }
+        /// <summary>
+        /// The public facing portal (url) path to the special system directory for that portal
+        /// </summary>
+        public string HomeSystemDirectory { get; set; }
 
-		public int HomeTabId { get; set; }
+        /// <summary>
+        /// The tab (page) ID of the home page of this portal
+        /// </summary>
+        public int HomeTabId { get; set; }
 
-		public float HostFee { get; set; }
+        /// <summary>
+        /// If hosting fees are enabled, this is the amount to charge
+        /// </summary>
+        public float HostFee { get; set; }
 
-		public int HostSpace { get; set; }
+        /// <summary>
+        /// If hosting fees are enabled, this would be the allowed host space for the subscription
+        /// </summary>
+        public int HostSpace { get; set; }
 
-		public string KeyWords { get; set; }
+        /// <summary>
+        /// A string containing keyworks for the built-in seach indexer and search engines
+        /// </summary>
+        public string KeyWords { get; set; }
 
-		public int LoginTabId { get; set; }
+        /// <summary>
+        /// The tab (page) ID of the login page
+        /// </summary>
+        public int LoginTabId { get; set; }
 
-		public string LogoFile { get; set; }
+        /// <summary>
+        /// The logo image file for this portal, can be used by themes and is used by the logo skinObject
+        /// </summary>
+        public string LogoFile { get; set; }
 
-		public int PageQuota { get; set; }
+        /// <summary>
+        /// If hosting fees are enabled, this would be the page quota allowed in the subscription
+        /// </summary>
+        public int PageQuota { get; set; }
 
-		public int Pages { get; set; }
+        /// <summary>
+        /// The number of pages this portal contains
+        /// </summary>
+        public int Pages { get; set; }
 
-		public int PortalId { get; set; }
+        /// <summary>
+        /// The ID of this portal (site)
+        /// </summary>
+        public int PortalId { get; set; }
 
-		public PortalAliasInfo PortalAlias { get; set; }
+        /// <summary>
+        /// The portal alias for this portal
+        /// </summary>
+        public PortalAliasInfo PortalAlias { get; set; }
 
-		public PortalAliasInfo PrimaryAlias { get; set; }
+        /// <summary>
+        /// The default portal alias for this portal
+        /// </summary>
+        public PortalAliasInfo PrimaryAlias { get; set; }
 
-		public string PortalName { get; set; }
+        /// <summary>
+        /// The name of this portal (site), used in menus, messages, logs, etc.
+        /// </summary>
+        public string PortalName { get; set; }
 
-		public int RegisteredRoleId { get; set; }
+        /// <summary>
+        /// The role ID that represents registered users
+        /// </summary>
+        public int RegisteredRoleId { get; set; }
 
-		public string RegisteredRoleName { get; set; }
+        /// <summary>
+        /// The role name that represents registered users
+        /// </summary>
+        public string RegisteredRoleName { get; set; }
 
-		public int RegisterTabId { get; set; }
+        /// <summary>
+        /// The tab (page) id of the registration page
+        /// </summary>
+        public int RegisterTabId { get; set; }
 
+        /// <summary>
+        /// The registration settings for this portal
+        /// </summary>
         public RegistrationSettings Registration { get; set; }
 
+        /// <summary>
+        /// The tab (page) id where the search results are located
+        /// </summary>
         public int SearchTabId { get; set; }
 
         [Obsolete("Deprecated in 8.0.0. Scheduled removal in v10.0.0.")]
         public int SiteLogHistory { get; set; }
 
-		public int SplashTabId { get; set; }
+        /// <summary>
+        /// The id of the tab (page) that is used as a splash page
+        /// </summary>
+        public int SplashTabId { get; set; }
 
-		public int SuperTabId { get; set; }
+        /// <summary>
+        /// The tab (page) id of the SuperUser (Host)
+        /// </summary>
+        public int SuperTabId { get; set; }
 
-		public int UserQuota { get; set; }
+        /// <summary>
+        /// If hosting fees are enabled, this is the page quote of the subscription
+        /// </summary>
+        public int UserQuota { get; set; }
 
-		public int UserRegistration { get; set; }
+        /// <summary>
+        /// This represents the user registration type <see cref="Globals.PortalRegistrationType"/> for the meaning of this integer
+        /// </summary>
+        public int UserRegistration { get; set; }
 
-		public int Users { get; set; }
+        /// <summary>
+        /// The number of users this portal conains
+        /// </summary>
+        public int Users { get; set; }
 
-		public int UserTabId { get; set; }
+        /// <summary>
+        /// The tab (page) ID where the user profile is located
+        /// </summary>
+        public int UserTabId { get; set; }
 
+        /// <summary>
+        /// The tab (page) id where the terms text is located (terms and conditions)
+        /// </summary>
         public int TermsTabId { get; set; }
 
-		public int PrivacyTabId { get; set; }
-        
+        /// <summary>
+        /// The tab (page) id where the privacy text is located (privacy policy)
+        /// </summary>
+        public int PrivacyTabId { get; set; }
+
+        /// <summary>
+        /// The dnn styles for this portal, these get injected on the page top as css custom properties
+        /// </summary>
+        public PortalStyles Styles { get; set; }
+
         #endregion
 
         #region Read-Only Properties

--- a/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
@@ -36,11 +36,14 @@ using DotNetNuke.Services.Localization;
 using DotNetNuke.UI.Skins;
 using DotNetNuke.Entities.Controllers;
 using DotNetNuke.Web.Client;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotNetNuke.Entities.Portals
 {
     public class PortalSettingsController : IPortalSettingsController
     {
+        protected readonly IPortalStylesController PortalStylesController;
+
         public static IPortalSettingsController Instance()
         {
             var controller = ComponentFactory.GetComponent<IPortalSettingsController>("PortalSettingsController");
@@ -48,8 +51,13 @@ namespace DotNetNuke.Entities.Portals
             {
                 ComponentFactory.RegisterComponent<IPortalSettingsController, PortalSettingsController>("PortalSettingsController");
             }
-
+            
             return ComponentFactory.GetComponent<IPortalSettingsController>("PortalSettingsController");
+        }
+
+        public PortalSettingsController()
+        {
+            PortalStylesController = Globals.DependencyProvider.GetRequiredService<IPortalStylesController>();
         }
 
         public virtual void ConfigureActiveTab(PortalSettings portalSettings)
@@ -324,7 +332,7 @@ namespace DotNetNuke.Entities.Portals
             setting = settings.GetValueOrDefault("DataConsentDelayMeasurement", "d");
             portalSettings.DataConsentDelayMeasurement = setting;
 
-            portalSettings.Styles = PortalStylesController.Instance().GetPortalStyles(portalSettings.PortalId);
+            portalSettings.Styles = PortalStylesController.GetPortalStyles(portalSettings.PortalId);
         }
 
         protected virtual void UpdateSkinSettings(TabInfo activeTab, PortalSettings portalSettings)

--- a/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
@@ -324,6 +324,7 @@ namespace DotNetNuke.Entities.Portals
             setting = settings.GetValueOrDefault("DataConsentDelayMeasurement", "d");
             portalSettings.DataConsentDelayMeasurement = setting;
 
+            portalSettings.Styles = PortalStylesController.Instance().GetPortalStyles(portalSettings.PortalId);
         }
 
         protected virtual void UpdateSkinSettings(TabInfo activeTab, PortalSettings portalSettings)

--- a/DNN Platform/Library/Entities/Portals/PortalStyles.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStyles.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿#region copyright
+
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,6 +13,9 @@ using System.Threading.Tasks;
 
 namespace DotNetNuke.Entities.Portals
 {
+    /// <summary>
+    /// Provides css custom properties to customize the Dnn UI in the platform, themes and modules for a overall consistent look
+    /// </summary>
     public class PortalStyles
     {
         /// <summary>

--- a/DNN Platform/Library/Entities/Portals/PortalStyles.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStyles.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNetNuke.Entities.Portals
+{
+    public class PortalStyles
+    {
+        /// <summary>
+        /// The Portal primary Color
+        /// </summary>
+        public StyleColorBase PrimaryColor { get; set; }
+
+        /// <summary>
+        /// A lighter version of the primary color
+        /// </summary>
+        public StyleColorBase PrimaryColorLight { get; set; }
+
+        /// <summary>
+        /// A darker version of the primary color
+        /// </summary>
+        public StyleColorBase PrimaryColorDark { get; set; }
+
+        /// <summary>
+        /// A color that has great contrasts against the primary color
+        /// </summary>
+        public StyleColorBase PrimaryColorContrast { get; set; }
+
+        /// <summary>
+        /// The Portal secondary Color
+        /// </summary>
+        public StyleColorBase SecondaryColor { get; set; }
+
+        /// <summary>
+        /// A lighter version of the secondary color
+        /// </summary>
+        public StyleColorBase SecondaryColorLight { get; set; }
+
+        /// <summary>
+        /// A darker version of the secondary color
+        /// </summary>
+        public StyleColorBase SecondaryColorDark { get; set; }
+
+        /// <summary>
+        /// A color that has great contrasts against the secondary color
+        /// </summary>
+        public StyleColorBase SecondaryColorContrast { get; set; }
+
+        /// <summary>
+        /// The Portal tertiary Color
+        /// </summary>
+        public StyleColorBase TertiaryColor { get; set; }
+
+        /// <summary>
+        /// A lighter version of the tertiary color
+        /// </summary>
+        public StyleColorBase TertiaryColorLight { get; set; }
+
+        /// <summary>
+        /// A darker version of the tertiary color
+        /// </summary>
+        public StyleColorBase TertiaryColorDark { get; set; }
+
+        /// <summary>
+        /// A color that has great contrasts against the tertiary color
+        /// </summary>
+        public StyleColorBase TertiaryColorContrast { get; set; }
+
+        /// <summary>
+        /// The default border radius for common UI elements such a dialogs, tabs, cards, etc.
+        /// </summary>
+        public int DefaultRadius { get; set; }
+
+        /// <summary>
+        /// The radius of button borders
+        /// </summary>
+        public int ButtonRadius { get; set; }
+
+
+    }
+}

--- a/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
@@ -36,20 +36,6 @@ namespace DotNetNuke.Entities.Portals
         private const string BUTTON_RADIUS = "ButtonRadius";
 
         /// <summary>
-        /// Gets an instance of the PortalStylescontroller
-        /// </summary>
-        /// <returns></returns>
-        public static IPortalStylesController Instance()
-        {
-            var controller = ComponentFactory.GetComponent<IPortalStylesController>("PortalStylesController");
-            if (controller == null)
-            {
-                ComponentFactory.RegisterComponent<IPortalStylesController, PortalStylesController>("PortalStylesController");
-            }
-            return ComponentFactory.GetComponent<IPortalStylesController>("PortalStylesController");
-        }
-
-        /// <summary>
         /// Gets the portal styles for the given portal
         /// </summary>
         /// <param name="portalId">The Id of the portal</param>

--- a/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
@@ -1,23 +1,7 @@
 ﻿#region Copyright
 
-// 
-// DotNetNuke® - http://www.dotnetnuke.com
-// Copyright (c) 2002-2018
-// by DotNetNuke Corporation
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
-// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
-// of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-// DEALINGS IN THE SOFTWARE.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #endregion
 

--- a/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
@@ -1,0 +1,128 @@
+﻿#region Copyright
+
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2018
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+#endregion
+
+
+#region usings
+using DotNetNuke.Collections;
+using DotNetNuke.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+#endregion
+
+namespace DotNetNuke.Entities.Portals
+{
+    class PortalStylesController : IPortalStylesController
+    {
+        private const string PRIMARY_COLOR = "PrimaryColor";
+        private const string PRIMARY_COLOR_LIGHT = "PrimaryColorLight";
+        private const string PRIMARY_COLOR_DARK = "PrimaryColorDark";
+        private const string PRIMARY_COLOR_CONTRAST = "PrimaryColorContrast";
+        private const string SECONDARY_COLOR = "SecondaryColor";
+        private const string SECONDARY_COLOR_LIGHT = "SecondaryColorLight";
+        private const string SECONDARY_COLOR_DARK = "SecondaryColorDark";
+        private const string SECONDARY_COLOR_CONTRAST = "SecondaryColorContrast";
+        private const string TERTIARY_COLOR = "TertiaryColor";
+        private const string TERTIARY_COLOR_LIGHT = "TertiaryColorLight";
+        private const string TERTIARY_COLOR_DARK = "TertiaryColorDark";
+        private const string TERTIARY_COLOR_CONTRAST = "TertiaryColorContrast";
+        private const string DEFAULT_RADIUS = "DefaultRadius";
+        private const string BUTTON_RADIUS = "ButtonRadius";
+
+        /// <summary>
+        /// Gets an instance of the PortalStylescontroller
+        /// </summary>
+        /// <returns></returns>
+        public static IPortalStylesController Instance()
+        {
+            var controller = ComponentFactory.GetComponent<IPortalStylesController>("PortalStylesController");
+            if (controller == null)
+            {
+                ComponentFactory.RegisterComponent<IPortalStylesController, PortalStylesController>("PortalStylesController");
+            }
+            return ComponentFactory.GetComponent<IPortalStylesController>("PortalStylesController");
+        }
+
+        /// <summary>
+        /// Gets the portal styles for the given portal
+        /// </summary>
+        /// <param name="portalId">The Id of the portal</param>
+        /// <returns></returns>
+        public PortalStyles GetPortalStyles(int portalId)
+        {
+            var settings = PortalController.Instance.GetPortalSettings(portalId);
+            var portalStyles = new PortalStyles();
+
+            portalStyles.PrimaryColor = new StyleColorBase(settings.GetValueOrDefault(PRIMARY_COLOR, "3792ED"));
+            portalStyles.PrimaryColorLight = new StyleColorBase(settings.GetValueOrDefault(PRIMARY_COLOR_LIGHT, "6CB6F3"));
+            portalStyles.PrimaryColorDark = new StyleColorBase(settings.GetValueOrDefault(PRIMARY_COLOR_DARK, "0D569E"));
+            portalStyles.PrimaryColorContrast = new StyleColorBase(settings.GetValueOrDefault(PRIMARY_COLOR_CONTRAST, GetContrastColor(portalStyles.PrimaryColor)));
+
+            portalStyles.SecondaryColor = new StyleColorBase(settings.GetValueOrDefault(SECONDARY_COLOR, "F5F5F5"));
+            portalStyles.SecondaryColorLight = new StyleColorBase(settings.GetValueOrDefault(SECONDARY_COLOR_LIGHT, "FEFEFE"));
+            portalStyles.SecondaryColorDark = new StyleColorBase(settings.GetValueOrDefault(SECONDARY_COLOR_DARK, "E8E8E8"));
+            portalStyles.SecondaryColorContrast = new StyleColorBase(settings.GetValueOrDefault(SECONDARY_COLOR_CONTRAST, GetContrastColor(portalStyles.SecondaryColor)));
+
+            portalStyles.TertiaryColor = new StyleColorBase(settings.GetValueOrDefault(TERTIARY_COLOR, "EAEAEA"));
+            portalStyles.TertiaryColorLight = new StyleColorBase(settings.GetValueOrDefault(TERTIARY_COLOR_LIGHT, "F2F2F2"));
+            portalStyles.TertiaryColorDark = new StyleColorBase(settings.GetValueOrDefault(TERTIARY_COLOR_DARK, "D8D8D8"));
+            portalStyles.TertiaryColorContrast = new StyleColorBase(settings.GetValueOrDefault(TERTIARY_COLOR_CONTRAST, GetContrastColor(portalStyles.TertiaryColor)));
+
+            portalStyles.DefaultRadius = settings.GetValueOrDefault(DEFAULT_RADIUS, 3);
+            portalStyles.ButtonRadius = settings.GetValueOrDefault(BUTTON_RADIUS, 3);
+
+            return portalStyles;
+        }
+
+        public void UpdatePortalStyles(int portalId, PortalStyles portalStyles)
+        {
+            PortalController.Instance.UpdatePortalSetting(portalId, PRIMARY_COLOR, portalStyles.PrimaryColor.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, PRIMARY_COLOR_LIGHT, portalStyles.PrimaryColorLight.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, PRIMARY_COLOR_DARK, portalStyles.PrimaryColorDark.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, PRIMARY_COLOR_CONTRAST, portalStyles.PrimaryColorContrast.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, SECONDARY_COLOR, portalStyles.SecondaryColor.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, SECONDARY_COLOR_LIGHT, portalStyles.SecondaryColorLight.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, SECONDARY_COLOR_DARK, portalStyles.SecondaryColorDark.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, SECONDARY_COLOR_CONTRAST, portalStyles.SecondaryColorContrast.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, TERTIARY_COLOR, portalStyles.TertiaryColor.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, TERTIARY_COLOR_LIGHT, portalStyles.TertiaryColorLight.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, TERTIARY_COLOR_DARK, portalStyles.TertiaryColorDark.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, TERTIARY_COLOR_CONTRAST, portalStyles.TertiaryColorContrast.HexValue, false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, DEFAULT_RADIUS, portalStyles.DefaultRadius.ToString(), false, null, false);
+            PortalController.Instance.UpdatePortalSetting(portalId, BUTTON_RADIUS, portalStyles.ButtonRadius.ToString(), false, null, true);
+        }
+
+        /// <summary>
+        /// Gets white or black css color depending on which provides the most contrast to the base color
+        /// </summary>
+        /// <param name="color">The color to contrast agains</param>
+        /// <returns>"000000" or "FFFFFF"</returns>
+        public string GetContrastColor(StyleColorBase color)
+        {
+            string result = (color.Red / 255 * 0.299 + color.Green / 255 * 0.587 + color.Blue / 255 * 0.114) > 186 ? "000000" : "FFFFFF";
+            return result;
+        }
+    }
+}

--- a/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStylesController.cs
@@ -18,7 +18,10 @@ using System.Threading.Tasks;
 
 namespace DotNetNuke.Entities.Portals
 {
-    class PortalStylesController : IPortalStylesController
+    /// <summary>
+    /// Gets or Sets the portal styles
+    /// </summary>
+    public class PortalStylesController : IPortalStylesController
     {
         private const string PRIMARY_COLOR = "PrimaryColor";
         private const string PRIMARY_COLOR_LIGHT = "PrimaryColorLight";

--- a/DNN Platform/Library/Entities/Portals/StyleColorBase.cs
+++ b/DNN Platform/Library/Entities/Portals/StyleColorBase.cs
@@ -1,0 +1,189 @@
+﻿#region Copyright
+
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2018
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+#endregion
+
+#region usings
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+#endregion
+
+
+
+namespace DotNetNuke.Entities.Portals
+{
+    /// <summary>
+    /// Represents a CSS color and it's components
+    /// </summary>
+    public class StyleColorBase
+    {
+        private enum Component
+        {
+            red,
+            green,
+            blue
+        }
+
+        private string _hex;
+
+        public StyleColorBase()
+        {
+            _hex = "FFFFFF";
+        }
+
+        public StyleColorBase(string hexValue)
+        {
+            if (IsValidCssColor(hexValue))
+            {
+                this.HexValue = ExpandColor(hexValue);
+            }
+            else
+            {
+                this.HexValue = ExpandColor("FFFFFF");
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the red component as a byte between 0 and 255
+        /// </summary>
+        public byte Red
+        {
+            get { return GetComponent(Component.red); }
+            set { SetComponent(Component.red, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the green component as a byte between 0 and 255
+        /// </summary>
+        public byte Green
+        {
+            get { return GetComponent(Component.green); }
+            set { SetComponent(Component.green, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the blue component as a byte between 0 and 255
+        /// </summary>
+        public byte Blue
+        {
+            get { return GetComponent(Component.blue); }
+            set { SetComponent(Component.blue, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the color using a 3 or 6 characters hex string such as 0088FF
+        /// </summary>
+        public string HexValue
+        {
+            get { return _hex; }
+            set
+            {
+                if (IsValidCssColor(value))
+                {
+                    _hex = ExpandColor(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// If possible, returns a shorter sting for the hex color value
+        /// ex: AABBCC would return ABC
+        /// </summary>
+        public string MinifiedHex
+        {
+            get
+            {
+                if (
+                    _hex[0] == _hex[1] && 
+                    _hex[2] == _hex[3] &&
+                    _hex[4] == _hex[5]
+                    )
+                {
+                    return _hex[0].ToString() + _hex[2].ToString() + _hex[4].ToString();
+                }
+                return _hex;
+            }
+        }
+
+        private bool IsValidCssColor(string hexValue)
+        {
+            if (string.IsNullOrWhiteSpace(hexValue))
+            {
+                throw new ArgumentNullException("You need to provide a CSS color value in the constructor");
+            }
+            var regex = new Regex(@"([\da-f]{3}){1,2}", RegexOptions.IgnoreCase);
+            if (!regex.IsMatch(hexValue))
+            {
+                throw new ArgumentOutOfRangeException($"The value {hexValue} that was provided is not valid, it needs to be 3 or 6 character long hexadecimal string without the # sing");
+            }
+            return true;
+        }
+
+        private static string ExpandColor(string hexValue)
+        {
+            if (hexValue.Length == 6)
+            {
+                return hexValue.ToUpperInvariant();
+            }
+            string value;
+            var r = hexValue[0];
+            var g = hexValue[1];
+            var b = hexValue[2];
+            value = string.Concat(r, r, g, g, b, b);
+            return value.ToUpperInvariant();
+        }
+
+        private byte GetComponent(Component comp)
+        {
+            switch (comp)
+            {
+                case Component.red:
+                    return byte.Parse(_hex.Substring(0, 2), System.Globalization.NumberStyles.HexNumber);
+                case Component.green:
+                    return byte.Parse(_hex.Substring(2, 2), System.Globalization.NumberStyles.HexNumber);
+                case Component.blue:
+                    return byte.Parse(_hex.Substring(4, 2), System.Globalization.NumberStyles.HexNumber);
+                default:
+                    return 0;
+            }
+        }
+
+        private void SetComponent(Component comp, byte value)
+        {         
+            switch (comp)
+            {
+                case Component.red:
+                    _hex = _hex.Remove(0, 2).Insert(0, $"{value:x2}");
+                    break;
+                case Component.green:
+                    _hex = _hex.Remove(2, 2).Insert(2, $"{value:x2}");
+                    break;
+                case Component.blue:
+                    _hex = _hex.Remove(4, 2).Insert(4, $"{value:x2}");
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/DNN Platform/Library/Entities/Portals/StyleColorBase.cs
+++ b/DNN Platform/Library/Entities/Portals/StyleColorBase.cs
@@ -1,23 +1,7 @@
 ﻿#region Copyright
 
-// 
-// DotNetNuke® - http://www.dotnetnuke.com
-// Copyright (c) 2002-2018
-// by DotNetNuke Corporation
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
-// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
-// of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-// DEALINGS IN THE SOFTWARE.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #endregion
 
@@ -46,11 +30,18 @@ namespace DotNetNuke.Entities.Portals
 
         private string _hex;
 
+        /// <summary>
+        /// Instantiates a new StyleColor with the default white color
+        /// </summary>
         public StyleColorBase()
         {
             _hex = "FFFFFF";
         }
 
+        /// <summary>
+        /// Instantiates a new StyleColor with the provided color but falls back to white if not provided or invalid
+        /// </summary>
+        /// <param name="hexValue"></param>
         public StyleColorBase(string hexValue)
         {
             if (IsValidCssColor(hexValue))

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -1,4 +1,6 @@
-﻿using DotNetNuke.DependencyInjection;
+﻿using System;
+using DotNetNuke.DependencyInjection;
+using DotNetNuke.Entities.Portals;
 using DotNetNuke.UI.Modules;
 using DotNetNuke.UI.Modules.Html5;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +14,13 @@ namespace DotNetNuke
             services.AddSingleton<WebFormsModuleControlFactory>();
             services.AddSingleton<Html5ModuleControlFactory>();
             services.AddSingleton<ReflectedModuleControlFactory>();
+
+            ConfigureEntityServices(services);
+        }
+
+        private void ConfigureEntityServices(IServiceCollection services)
+        {
+            services.AddSingleton<IPortalStylesController, PortalStylesController>();
         }
     }
 }

--- a/Website/Default.aspx
+++ b/Website/Default.aspx
@@ -12,7 +12,8 @@
     <meta id="MetaCopyright" runat="Server" name="COPYRIGHT" Visible="False"/>
     <meta id="MetaGenerator" runat="Server" name="GENERATOR" Visible="False"/>
     <meta id="MetaAuthor" runat="Server" name="AUTHOR" Visible="False"/>
-    <meta id="MetaRobots" runat="server" name="ROBOTS" Visible="False" />    
+    <meta id="MetaRobots" runat="server" name="ROBOTS" Visible="False" />
+    <asp:Literal runat="server" id="CssCustomProperties"></asp:Literal>
     <asp:PlaceHolder runat="server" ID="ClientDependencyHeadCss"></asp:PlaceHolder>
     <asp:PlaceHolder runat="server" ID="ClientDependencyHeadJs"></asp:PlaceHolder>
     <asp:placeholder id="CSS" runat="server" />

--- a/Website/Default.aspx.cs
+++ b/Website/Default.aspx.cs
@@ -730,40 +730,41 @@ namespace DotNetNuke.Framework
         {
             string cacheKey = $"Dnn_Css_Custom_Properties_{PortalSettings.PortalId}";
             string cache = Common.Utilities.DataCache.GetCache<string>(cacheKey);
-            if (string.IsNullOrEmpty(cache))
+
+            if (!string.IsNullOrEmpty(cache))
             {
-                var portalStyles = PortalSettings.Styles;
-                var sb = new StringBuilder();
-
-                sb
-                .AppendLine(@"<style type=""text/css"">")
-                .AppendLine(@":root {")
-
-                .AppendLine($"--dnn-color-primary: #{portalStyles.PrimaryColor.MinifiedHex};")
-                .AppendLine($"--dnn-color-primary-light: #{portalStyles.PrimaryColorLight.MinifiedHex};")
-                .AppendLine($"--dnn-color-primary-dark: #{portalStyles.PrimaryColorDark.MinifiedHex};")
-                .AppendLine($"--dnn-color-primary-contrast: #{portalStyles.PrimaryColorContrast.MinifiedHex};")
-
-                .AppendLine($"--dnn-color-secondary: #{portalStyles.SecondaryColor.MinifiedHex};")
-                .AppendLine($"--dnn-color-secondary-light: #{portalStyles.SecondaryColorLight.MinifiedHex};")
-                .AppendLine($"--dnn-color-secondary-dark: #{portalStyles.SecondaryColorDark.MinifiedHex};")
-                .AppendLine($"--dnn-color-secondary-contrast: #{portalStyles.SecondaryColorContrast.MinifiedHex};")
-
-                .AppendLine($"--dnn-color-tertiary: #{portalStyles.TertiaryColor.MinifiedHex};")
-                .AppendLine($"--dnn-color-tertiary-light: #{portalStyles.TertiaryColorLight.MinifiedHex};")
-                .AppendLine($"--dnn-color-tertiary-dark: #{portalStyles.TertiaryColorDark.MinifiedHex};")
-                .AppendLine($"--dnn-color-tertiary-contrast: #{portalStyles.TertiaryColorContrast.MinifiedHex};")
-
-                .AppendLine($"--dnn-default-radius: {portalStyles.DefaultRadius}px;")
-                .AppendLine($"--dnn-button-radius: {portalStyles.ButtonRadius}px;")
-
-                .AppendLine(@"}")
-                .AppendLine(@"</style>");
-
-                Common.Utilities.DataCache.SetCache(cacheKey, sb.ToString());
+                return cache;
             }
-            cache = Common.Utilities.DataCache.GetCache<string>(cacheKey);
-            return cache;
+           
+            var portalStyles = PortalSettings.Styles;
+            var sb = new StringBuilder();
+            sb
+            .AppendLine(@"<style type=""text/css"">")
+            .AppendLine(@":root {")
+
+            .AppendLine($"--dnn-color-primary: #{portalStyles.PrimaryColor.MinifiedHex};")
+            .AppendLine($"--dnn-color-primary-light: #{portalStyles.PrimaryColorLight.MinifiedHex};")
+            .AppendLine($"--dnn-color-primary-dark: #{portalStyles.PrimaryColorDark.MinifiedHex};")
+            .AppendLine($"--dnn-color-primary-contrast: #{portalStyles.PrimaryColorContrast.MinifiedHex};")
+
+            .AppendLine($"--dnn-color-secondary: #{portalStyles.SecondaryColor.MinifiedHex};")
+            .AppendLine($"--dnn-color-secondary-light: #{portalStyles.SecondaryColorLight.MinifiedHex};")
+            .AppendLine($"--dnn-color-secondary-dark: #{portalStyles.SecondaryColorDark.MinifiedHex};")
+            .AppendLine($"--dnn-color-secondary-contrast: #{portalStyles.SecondaryColorContrast.MinifiedHex};")
+
+            .AppendLine($"--dnn-color-tertiary: #{portalStyles.TertiaryColor.MinifiedHex};")
+            .AppendLine($"--dnn-color-tertiary-light: #{portalStyles.TertiaryColorLight.MinifiedHex};")
+            .AppendLine($"--dnn-color-tertiary-dark: #{portalStyles.TertiaryColorDark.MinifiedHex};")
+            .AppendLine($"--dnn-color-tertiary-contrast: #{portalStyles.TertiaryColorContrast.MinifiedHex};")
+
+            .AppendLine($"--dnn-default-radius: {portalStyles.DefaultRadius}px;")
+            .AppendLine($"--dnn-button-radius: {portalStyles.ButtonRadius}px;")
+
+            .AppendLine(@"}")
+            .AppendLine(@"</style>");
+
+            Common.Utilities.DataCache.SetCache(cacheKey, sb.ToString());
+            return sb.ToString();
         }
 
         /// -----------------------------------------------------------------------------

--- a/Website/Default.aspx.cs
+++ b/Website/Default.aspx.cs
@@ -692,6 +692,9 @@ namespace DotNetNuke.Framework
                 }
             }
 
+            //Inject Dnn custom css properties
+            CssCustomProperties.Text = GenerateCssCustomProperties();
+
             //add CSS links
             ClientResourceManager.RegisterDefaultStylesheet(this, string.Concat(Globals.ApplicationPath, "/Resources/Shared/stylesheets/dnndefault/7.0.0/default.css"));
             ClientResourceManager.RegisterIEStylesheet(this, string.Concat(Globals.HostPath, "ie.css"));
@@ -722,7 +725,47 @@ namespace DotNetNuke.Framework
 		        AJAX.GetScriptManager(this).AsyncPostBackTimeout = Host.AsyncTimeout;
 	        }
         }
-        
+
+        private string GenerateCssCustomProperties()
+        {
+            string cacheKey = $"Dnn_Css_Custom_Properties_{PortalSettings.PortalId}";
+            string cache = Common.Utilities.DataCache.GetCache<string>(cacheKey);
+            if (string.IsNullOrEmpty(cache))
+            {
+                var portalStyles = PortalSettings.Styles;
+                var sb = new StringBuilder();
+
+                sb
+                .AppendLine(@"<style type=""text/css"">")
+                .AppendLine(@":root {")
+
+                .AppendLine($"--dnn-color-primary: #{portalStyles.PrimaryColor.MinifiedHex};")
+                .AppendLine($"--dnn-color-primary-light: #{portalStyles.PrimaryColorLight.MinifiedHex};")
+                .AppendLine($"--dnn-color-primary-dark: #{portalStyles.PrimaryColorDark.MinifiedHex};")
+                .AppendLine($"--dnn-color-primary-contrast: #{portalStyles.PrimaryColorContrast.MinifiedHex};")
+
+                .AppendLine($"--dnn-color-secondary: #{portalStyles.SecondaryColor.MinifiedHex};")
+                .AppendLine($"--dnn-color-secondary-light: #{portalStyles.SecondaryColorLight.MinifiedHex};")
+                .AppendLine($"--dnn-color-secondary-dark: #{portalStyles.SecondaryColorDark.MinifiedHex};")
+                .AppendLine($"--dnn-color-secondary-contrast: #{portalStyles.SecondaryColorContrast.MinifiedHex};")
+
+                .AppendLine($"--dnn-color-tertiary: #{portalStyles.TertiaryColor.MinifiedHex};")
+                .AppendLine($"--dnn-color-tertiary-light: #{portalStyles.TertiaryColorLight.MinifiedHex};")
+                .AppendLine($"--dnn-color-tertiary-dark: #{portalStyles.TertiaryColorDark.MinifiedHex};")
+                .AppendLine($"--dnn-color-tertiary-contrast: #{portalStyles.TertiaryColorContrast.MinifiedHex};")
+
+                .AppendLine($"--dnn-default-radius: {portalStyles.DefaultRadius}px;")
+                .AppendLine($"--dnn-button-radius: {portalStyles.ButtonRadius}px;")
+
+                .AppendLine(@"}")
+                .AppendLine(@"</style>");
+
+                Common.Utilities.DataCache.SetCache(cacheKey, sb.ToString());
+            }
+            cache = Common.Utilities.DataCache.GetCache<string>(cacheKey);
+            return cache;
+        }
+
         /// -----------------------------------------------------------------------------
         /// <summary>
         /// Initialize the Scrolltop html control which controls the open / closed nature of each module 

--- a/Website/Default.aspx.cs
+++ b/Website/Default.aspx.cs
@@ -746,16 +746,26 @@ namespace DotNetNuke.Framework
             .AppendLine($"--dnn-color-primary-light: #{portalStyles.PrimaryColorLight.MinifiedHex};")
             .AppendLine($"--dnn-color-primary-dark: #{portalStyles.PrimaryColorDark.MinifiedHex};")
             .AppendLine($"--dnn-color-primary-contrast: #{portalStyles.PrimaryColorContrast.MinifiedHex};")
+            .AppendLine($"--dnn-color-primary-r: {portalStyles.PrimaryColor.Red};")
+            .AppendLine($"--dnn-color-primary-g: {portalStyles.PrimaryColor.Green};")
+            .AppendLine($"--dnn-color-primary-b: {portalStyles.PrimaryColor.Blue};")
+
 
             .AppendLine($"--dnn-color-secondary: #{portalStyles.SecondaryColor.MinifiedHex};")
             .AppendLine($"--dnn-color-secondary-light: #{portalStyles.SecondaryColorLight.MinifiedHex};")
             .AppendLine($"--dnn-color-secondary-dark: #{portalStyles.SecondaryColorDark.MinifiedHex};")
             .AppendLine($"--dnn-color-secondary-contrast: #{portalStyles.SecondaryColorContrast.MinifiedHex};")
+            .AppendLine($"--dnn-color-secondary-r: {portalStyles.SecondaryColor.Red};")
+            .AppendLine($"--dnn-color-secondary-g: {portalStyles.SecondaryColor.Green};")
+            .AppendLine($"--dnn-color-secondary-b: {portalStyles.SecondaryColor.Blue};")
 
             .AppendLine($"--dnn-color-tertiary: #{portalStyles.TertiaryColor.MinifiedHex};")
             .AppendLine($"--dnn-color-tertiary-light: #{portalStyles.TertiaryColorLight.MinifiedHex};")
             .AppendLine($"--dnn-color-tertiary-dark: #{portalStyles.TertiaryColorDark.MinifiedHex};")
             .AppendLine($"--dnn-color-tertiary-contrast: #{portalStyles.TertiaryColorContrast.MinifiedHex};")
+            .AppendLine($"--dnn-color-tertiary-r: {portalStyles.TertiaryColor.Red};")
+            .AppendLine($"--dnn-color-tertiary-g: {portalStyles.TertiaryColor.Green};")
+            .AppendLine($"--dnn-color-tertiary-b: {portalStyles.TertiaryColor.Blue};")
 
             .AppendLine($"--dnn-default-radius: {portalStyles.DefaultRadius}px;")
             .AppendLine($"--dnn-button-radius: {portalStyles.ButtonRadius}px;")

--- a/Website/Default.aspx.designer.cs
+++ b/Website/Default.aspx.designer.cs
@@ -112,6 +112,15 @@ namespace DotNetNuke.Framework {
         protected global::System.Web.UI.HtmlControls.HtmlMeta MetaRobots;
         
         /// <summary>
+        /// CssCustomProperties control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Literal CssCustomProperties;
+        
+        /// <summary>
         /// ClientDependencyHeadCss control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
@david-poindexter @mitchelsellers 

Here is a first part to this project, it adds portalSettings support for the new Dnn Styles (custom css properties) and injects them in the head using cache.

After this is agreed upon, I will move on to consume them and seriously reducing or killing or making default.css a legacy optional thing by moving the css where it belongs (each module would consume the css variables instead of having their styles in default.css).

Let me know if you see wrong stuff or improvements and how you want to manage this.

I created a branch called project/webcomponents here where we can merge the whole project when we are done or I can submit this PR when agreed to the offical repository. This part is independent and is not a breaking change, it only adds the possibility of using those variables and (manually) editing them in the portal settings table...

I cannot built the release package locally, looks like there are some build issues again. But I can post the files to replace on a dnn10 instance if you want to test this.

It generates this:
![image](https://user-images.githubusercontent.com/6371568/60696361-6b6ab280-9eb3-11e9-8fa1-d06daf84b959.png)

Those are the default values fallback when no settings exist in the database.

Let me know your thoughts...